### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM nginx
+FROM busybox
 
-MAINTAINER Robert Stern <lexandro2000@gmail.com>
+COPY . /www/
 
-COPY . /usr/share/nginx/html
+EXPOSE 80
+
+CMD ["httpd","-f","-p","80","-h","/www"]


### PR DESCRIPTION
Using busybox with its buit-in webserver saves 130MB of image size.
